### PR TITLE
Pipeline: Removed SQL whitelisting, added temporary app registration client secret creation/deletion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/1.0.4
+    ref: refs/tags/1.0.6
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -25,21 +25,21 @@ jobs:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             FunctionAppName: $(FundingApprenticeshipEarningsFunctionAppName)
             OutputVariableName: FundingApprenticeshipEarningsFunctionAppSystemKey
-        - template: azure-pipelines-templates/deploy/step/sql-whitelist-ip.yml@das-platform-building-blocks
+        - template: azure-pipelines-templates/deploy/step/app-reg-new-temp-client-secret.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
-            SQLServerName: $(SharedSQLServerName)
+            AppRegistrationObjectId: $(AppRegistrationObjectId)
         - task: DotNetCoreCLI@2
           env:
             NServiceBusLicense: $(NServiceBusLicense)
-            AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+            AZURE_CLIENT_SECRET: $(AppRegistrationTemporaryClientSecret)
             EarningsFunctionKey: $(FundingApprenticeshipEarningsFunctionAppSystemKey)
           inputs:
             command: 'test'
             projects: |
               **/${{ parameters.SolutionBaseName }}.csproj
-        - template: azure-pipelines-templates/deploy/step/sql-remove-ip.yml@das-platform-building-blocks
+        - template: azure-pipelines-templates/deploy/step/app-reg-remove-client-secret.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
-            SQLServerName: $(SharedSQLServerName)
-            IPAddress: $(IPAddress)
+            AppRegistrationObjectId: $(AppRegistrationObjectId)
+            AppRegistrationClientSecretId: $(AppRegistrationTemporaryClientSecretId)


### PR DESCRIPTION
- SQL Server does not currently need to be accessed
- Pipeline now creates and deletes temporary app registration client secrets to avoid management of longer-lasting client secrets