### PR TITLE
DASD-13173 - Pipeline - Assistance on failed acceptance test retry capability in YAML pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,22 +38,7 @@ stages:
       SolutionBaseName: $(SolutionBaseName)
       BuildConfiguration: $(BuildConfiguration)
       AzureArtifactsFeed: dct-pkg
-- stage: Deploy_AT
-  dependsOn: Build
-  displayName: Deploy to AT
-  condition: and(succeeded(), eq(variables.Deploy, 'true'))
-  variables:
-  - group: DevTest Management Resources
-  - group: AT DevTest Shared Resources
-  - group: AT Automation Suite Variables
-  - group: AT das-funding-system-acceptance-tests
-  jobs:
-  - template: pipeline-templates/job/deploy.yml
-    parameters:
-      Environment: AT
-      SolutionBaseName: $(SolutionBaseName)
-      ServiceConnection: SFA-DAS-DevTest-ARM
-      AzureArtifactsFeed: dct-pkg
+
 - stage: Deploy_TEST
   dependsOn: Build
   displayName: Deploy to TEST
@@ -69,6 +54,7 @@ stages:
       SolutionBaseName: $(SolutionBaseName)
       ServiceConnection: SFA-DAS-DevTest-ARM
       AzureArtifactsFeed: dct-pkg
+
 - stage: Deploy_TEST2
   dependsOn: Build
   displayName: Deploy to TEST2
@@ -84,6 +70,7 @@ stages:
       SolutionBaseName: $(SolutionBaseName)
       ServiceConnection: SFA-DAS-DevTest-ARM
       AzureArtifactsFeed: dct-pkg
+
 - stage: Deploy_PP
   dependsOn: Build
   displayName: Deploy to PP

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -7,7 +7,7 @@ parameters:
 jobs:
 - deployment: RunAcceptanceTests
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'windows-latest'
   environment: ${{ parameters.Environment }}
   strategy:
     runOnce:
@@ -15,49 +15,57 @@ jobs:
         steps:
         - checkout: self
         - checkout: das-platform-automation
+
         - template: azure-pipelines-templates/deploy/step/wait-azure-devops-deployment.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             EnvironmentId: $(Environment.Id)
             PipelineName: $(Build.DefinitionName)
             RunId: $(Build.BuildId)
+
         - template: azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             ResourceName: $(FundingApprenticeshipEarningsFunctionAppName)
             RuleName: "FundingAcceptanceTestsEarnings"
+
         - template: azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             ResourceName: $(FundingApprenticeshipPaymentsFunctionAppName)
             RuleName: "FundingAcceptanceTestsPayments"
+
         - template: azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             ResourceName: $(ApprenticeshipsFunctionAppName)
             RuleName: "FundingAcceptanceTestsApps"
+
         - template: azure-pipelines-templates/deploy/step/function-app-get-system-key.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             FunctionAppName: $(FundingApprenticeshipEarningsFunctionAppName)
             OutputVariableName: FundingApprenticeshipEarningsFunctionAppSystemKey
+
         - template: azure-pipelines-templates/deploy/step/function-app-get-system-key.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             FunctionAppName: $(FundingApprenticeshipPaymentsFunctionAppName)
             OutputVariableName: FundingApprenticeshipPaymentsFunctionAppSystemKey
+
         - template: azure-pipelines-templates/deploy/step/app-reg-new-temp-client-secret.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             AppRegistrationObjectId: $(AppRegistrationObjectId)
+
         - template: azure-pipelines-templates/deploy/step/sql-whitelist-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             SQLServerName: $(SharedSQLServerName)
 
         - task: DotNetCoreCLI@2
-          condition: ne('${{ parameters.AzureArtifactsFeed }}', '')
           displayName: Restore - Including Custom Feed
+          condition: ne('${{ parameters.AzureArtifactsFeed }}', '')
           inputs:
             command: restore
             projects: '**/*.csproj'
@@ -67,6 +75,14 @@ jobs:
             includeNuGetOrg: true
 
         - task: DotNetCoreCLI@2
+          displayName: Build Acceptance Test Project
+          inputs:
+            command: build
+            projects: '**/SFA.DAS.Funding.SystemAcceptanceTests.csproj'
+            arguments: '--configuration Release --output $(Build.ArtifactStagingDirectory)/publish'
+
+        - task: VSTest@3
+          displayName: Run Acceptance Tests
           env:
             NServiceBusLicense: $(NServiceBusLicense)
             AZURE_CLIENT_SECRET: $(AppRegistrationTemporaryClientSecret)
@@ -74,17 +90,25 @@ jobs:
             PaymentsFunctionKey: $(PaymentsFunctionKey)
             ApprenticeshipsDbConnectionString: $(ApprenticeshipsDbConnectionString)
             EarningsDbConnectionString: $(EarningsDbConnectionString)
-            PaymentsDbConnectionString : $(PaymentsDbConnectionString)
-            ApprenticeshipServiceBearerTokenSigningKey : $(ApprenticeshipServiceBearerTokenSigningKey)
-            ApprenticeshipAzureFunctionKey : $(ApprenticeshipAzureFunctionKey)
+            PaymentsDbConnectionString: $(PaymentsDbConnectionString)
+            ApprenticeshipServiceBearerTokenSigningKey: $(ApprenticeshipServiceBearerTokenSigningKey)
+            ApprenticeshipAzureFunctionKey: $(ApprenticeshipAzureFunctionKey)
             EarningsOuterSubscriptionKey: $(EarningsOuterSubscriptionKey)
           inputs:
-            command: 'test'
-            projects: |
-              **/${{ parameters.SolutionBaseName }}.csproj
-            arguments: '--logger "trx;LogFileName=test_results.trx"'
+            testSelector: 'testAssemblies'
+            testAssemblyVer2: |
+              $(Build.ArtifactStagingDirectory)/publish/${{ parameters.SolutionBaseName }}.dll
+            searchFolder: '$(Build.ArtifactStagingDirectory)/publish'
+            testAdapterPath: '$(Build.ArtifactStagingDirectory)/publish'
+            runInParallel: false
+            maxCpuCount: 1
+            rerunFailedTests: true
+            maxAttempts: 2
+            failurePercentage: 30
+            rerunType: 'basedontestfailurepercentage'
 
         - task: PublishTestResults@2
+          displayName: Publish Test Results
           inputs:
             testResultsFormat: 'VSTest'
             testResultsFiles: '**/*.trx'
@@ -95,10 +119,12 @@ jobs:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             AppRegistrationObjectId: $(AppRegistrationObjectId)
             AppRegistrationClientSecretId: $(AppRegistrationTemporaryClientSecretId)
+
         - template: azure-pipelines-templates/deploy/step/appservice-remove-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             ResourceName: $(FundingApprenticeshipEarningsFunctionAppName)
+
         - template: azure-pipelines-templates/deploy/step/appservice-remove-ip.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}

--- a/src/SFA.DAS.Funding.SystemAcceptanceTests/SFA.DAS.Funding.SystemAcceptanceTests.csproj
+++ b/src/SFA.DAS.Funding.SystemAcceptanceTests/SFA.DAS.Funding.SystemAcceptanceTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="RestAssured.Net" Version="1.0.0" />
     <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />


### PR DESCRIPTION
The dotnetcli task needs to replace with VSTest@3 task to have retry capabilities, parallelism and other test control inputs. dotnetcli does not support any of this. VSTest requires DLL files to be run against. 

AT was removed as request by a developer as the test are not setup for AT.